### PR TITLE
職務経歴書の作成とブラッシュアップ

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+default_stages: [pre-commit]
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: detect-aws-credentials
+        args:
+          - --allow-missing-credentials
+      - id: end-of-file-fixer
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.18.1
+    hooks:
+    - id: markdownlint-cli2

--- a/README.md
+++ b/README.md
@@ -1,1 +1,105 @@
-# resume
+# 職務経歴書
+
+## 基本情報
+
+- **氏名**: 久松佳之
+- **GitHub**: [https://github.com/karia](https://github.com/karia)
+
+## 職務経歴
+
+### 株式会社つみき
+
+**インフラエンジニア / SRE**
+*2017年8月 - 現在 (約7年間)*
+
+#### 業務内容
+
+映画・ドラマレビューサービス「Filmarks」（月間1,000万UU規模）のインフラ基盤構築・運用およびサービスの信頼性向上に従事。サービスの成長に合わせてインフラアーキテクチャの設計・実装・最適化を主導。
+AWSとGoogle Cloudを活用した大規模サービスのインフラ設計・構築から、DevOpsプロセスの改善、セキュリティ対策まで幅広く担当。
+
+#### 主な実績と取り組み
+
+##### インフラモダナイゼーション・基盤構築 (2017年 - 現在)
+
+- RDSからAuroraへの移行計画策定と実行、Auto Scalingによる負荷対応自動化
+- Terraformによる大規模インフラのIaC化推進
+- データパイプライン基盤構築（ログ収集、S3/Redshift連携、外部API連携）
+- GitHub ActionsによるCI/CDパイプライン設計・実装
+
+**使用技術**: Terraform, AWS, GCP, GitHub Actions, Fluentd, Docker
+
+##### セキュリティ・運用自動化 (2024年 - 現在)
+
+- DDoS攻撃対応とAWS WAFルール設計による不正アクセス対策
+- 包括的監視システム構築（Mackerel、CloudWatch、NewRelic連携）
+- リリースプロセス自動化、EC2定期更新プロセス改善
+- インシデント対応手順整備、ポストモーテム文化定着
+
+**使用技術**: AWS WAF, Mackerel, CloudWatch, Ansible, git-pr-release
+
+##### 開発効率化・チーム支援 (2024年 - 現在)
+
+- ECS Fargate/Spotを活用したコンテナ基盤最適化、検証環境コスト70%削減
+- MySQL 8.0バージョンアップ計画
+- AI開発ツール導入支援、pre-commit品質チェック体制構築
+- 技術勉強会開催、新メンバーオンボーディング支援
+
+**使用技術**: ECS, Aurora MySQL, BigQuery, Claude Code, pre-commit, mise
+
+## 技術スタック
+
+### インフラ・クラウド
+
+- **AWS**: EC2, ECS (Fargate), RDS (Aurora MySQL), S3, CloudFront, WAF, Lambda, CloudWatch
+- **Google Cloud Platform**: BigQuery, Cloud Storage
+- **IaC**: Terraform, Ansible
+- **Monitoring**: Mackerel, NewRelic, CloudWatch, td-agent (Fluentd)
+
+### 開発・CI/CD
+
+- **CI/CD**: GitHub Actions, CircleCI
+- **Container**: Docker, AWS ECS, ECR
+- **Languages**: Python, Shell Script, Ruby, JavaScript
+- **Quality**: pre-commit, tflint, yamllint, shellcheck, ruff
+- **Package Management**: mise, bundler, npm
+
+### データ・アプリケーション
+
+- **Database**: MySQL 5.7/8.0, Aurora MySQL, Redis, Elasticsearch
+- **Data Warehouse**: Amazon Redshift, Google BigQuery
+- **Web**: Nginx, Unicorn, Sidekiq
+
+## 強み・アピールポイント
+
+- **フルスタックなインフラ知識**: ネットワーク層からアプリケーション層まで幅広い実装経験
+- **長期的な技術選定能力**: 7年間のサービス成長を支える技術選定と移行戦略の実績
+- **IaCの実践経験**: Terraformを活用した大規模インフラのコード化
+- **セキュリティ対応力**: DDoS攻撃やセキュリティインシデントへの迅速な対応経験
+- **問題解決能力**: 障害発生時の原因分析と根本解決への取り組み
+- **チーム貢献**: レトロスペクティブファシリテーション、技術勉強会開催、オンボーディング支援
+
+### 株式会社アニメイトラボ
+
+**職種**:
+**期間**:
+
+#### アニメイトラボでの業務内容
+
+#### アニメイトラボでの主な実績と取り組み
+
+**使用技術**:
+
+### ソフトバンクモバイル株式会社
+
+**職種**:
+**期間**:
+
+#### ソフトバンクモバイルでの業務内容
+
+#### ソフトバンクモバイルでの主な実績と取り組み
+
+**使用技術**:
+
+---
+
+最終更新日: 2025年9月22日

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+pre-commit = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,4 @@
 [tools]
 pre-commit = "latest"
+node = "lts"
+markdownlint-cli2 = "latest"


### PR DESCRIPTION
## Summary

- AI生成による職務経歴書の初回作成
- 2社分の経歴入力欄を追加（ソフトバンクモバイル、アニメイトラボ）
- PDF3ページ程度に収まるよう大幅圧縮とブラッシュアップを実施

## 主な変更内容

- 株式会社つみきの経歴を10項目から3カテゴリに統合
- 技術スタックを6カテゴリから3カテゴリに簡素化
- 強み・アピールポイントを箇条書きで簡潔に整理
- pre-commit設定とmarkdownlint導入によるコード品質向上

🤖 Generated with [Claude Code](https://claude.ai/code)