### PR TITLE
Improve PDF table styling

### DIFF
--- a/pdf-styles.css
+++ b/pdf-styles.css
@@ -74,3 +74,31 @@ a {
         content: none !important;
     }
 }
+
+/* 表のスタイル設定 */
+table {
+    border-collapse: collapse;
+    width: auto;
+    margin: 5px 0;
+}
+
+/* 表のセルに罫線を追加 */
+table th,
+table td {
+    border: 1px solid #ddd;
+    padding: 2px 4px;
+    line-height: 1.2;
+}
+
+/* 表の見出し(th)のフォントサイズを本文と同じにする */
+table th {
+    font-size: 10px;
+    font-weight: bold;
+    background-color: #f5f5f5;
+    text-align: left;
+}
+
+/* 表のデータセル(td)のフォントサイズ */
+table td {
+    font-size: 10px;
+}


### PR DESCRIPTION
## 概要
PDFの表のスタイルを改善

## 変更内容
- 表に罫線を追加
- 表の見出し(th)のフォントサイズを本文と同じ10pxに統一
- セル内の余白をコンパクトに調整（padding: 2px 4px）
- 表の幅をコンテンツに合わせて自動調整（width: auto）

🤖 Generated with [Claude Code](https://claude.ai/code)