### PR TITLE
Reduce font size from 10px to 9px for better PDF layout

### DIFF
--- a/pdf-styles.css
+++ b/pdf-styles.css
@@ -34,7 +34,7 @@ h5 { font-size: 10px; }
 
 /* 段落と通常テキスト */
 p, li, td {
-    font-size: 10px;
+    font-size: 9px;
 }
 
 /* 箇条書きの行間を少し広げる */


### PR DESCRIPTION
## Summary
* PDFレイアウト最適化のためフォントサイズを10pxから9pxに縮小

🤖 Generated with [Claude Code](https://claude.com/claude-code)