### PR TITLE
Add GitHub Actions workflow to generate PDF and create release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Create Release with PDF
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Generate PDF
+        run: |
+          npx markdown-pdf --css-path pdf-styles.css resume.md
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: resume.pdf
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- タグプッシュ時にPDFを自動生成し、GitHub Releaseに添付するワークフローを追加

## 使い方
1. タグを作成してプッシュ: `git tag v1.0.0 && git push origin v1.0.0`
2. GitHub Actionsが自動的にPDFを生成しreleaseを作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)