### PR TITLE
AWSサービスをカテゴリ別に整理しネストリスト化

### DIFF
--- a/pdf-styles.css
+++ b/pdf-styles.css
@@ -43,6 +43,17 @@ li {
     margin-bottom: 2px;
 }
 
+/* ネストされたリストのインデントを調整 */
+ul ul {
+    margin-left: 15px;
+    padding-left: 0;
+}
+
+ul ul li {
+    margin-left: 0;
+    padding-left: 0;
+}
+
 /* PDFでリンクのURLを非表示にする */
 a[href]:after,
 a[href]::after {

--- a/resume.md
+++ b/resume.md
@@ -125,7 +125,9 @@
 
 ### クラウド・SaaS
 
-- **AWS**: EC2, ECS (Fargate), RDS (Aurora), S3, CloudFront, WAF, Lambda, CloudWatch, API Gateway, DynamoDB, Redshift, DMS, ElastiCache, SES, Route53, etc
+- **AWS (Compute)**: EC2, ECS (Fargate), Lambda
+- **AWS (Database & Storage)**: RDS (Aurora), DynamoDB, Redshift, ElastiCache, S3
+- **AWS (Networking & Others)**: CloudFront, Route53, API Gateway, WAF, CloudWatch, DMS, SES
 - **Google Cloud**: BigQuery, Cloud Storage, Cloud Run Functions
 - **CI/CD**: GitHub Actions, CircleCI, AWS CodeDeploy
 - **モニタリング**: Mackerel, NewRelic, Bugsnag

--- a/resume.md
+++ b/resume.md
@@ -125,9 +125,10 @@
 
 ### クラウド・SaaS
 
-- **AWS (Compute)**: EC2, ECS (Fargate), Lambda
-- **AWS (Database & Storage)**: RDS (Aurora), DynamoDB, Redshift, ElastiCache, S3
-- **AWS (Networking & Others)**: CloudFront, Route53, API Gateway, WAF, CloudWatch, DMS, SES
+- **AWS**
+  - **Compute**: EC2, ECS (Fargate), Lambda
+  - **Database & Storage**: RDS (Aurora), DynamoDB, Redshift, ElastiCache, S3, OpenSearch Service, Athena
+  - **Networking & Others**: CloudFront, Route53, API Gateway, WAF, CloudWatch, DMS, SES, SNS, EventBridge
 - **Google Cloud**: BigQuery, Cloud Storage, Cloud Run Functions
 - **CI/CD**: GitHub Actions, CircleCI, AWS CodeDeploy
 - **モニタリング**: Mackerel, NewRelic, Bugsnag
@@ -139,7 +140,7 @@
 - **フレームワーク**: Ruby on Rails
 - **IaC**: Terraform, Ansible
 - **データベース**: MySQL, Redis, memcached, Elasticsearch
-- **ミドルウェア**: Docker, Nginx, td-agent (Fluentd)
+- **ミドルウェア・ツール**: Docker, Nginx, td-agent (Fluentd), ecspresso, lambroll, Locust
 
 ## 対外発表・ブログ・業務外活動
 


### PR DESCRIPTION
## Summary

- AWSサービスをAWS公式カテゴリ (Compute, Database & Storage, Networking & Others) に沿って3つのサブカテゴリに分類
- 見やすさ向上のため、ネストリスト形式に変更
- ネストリストのインデント調整用CSSを追加
- 不足していたAWSサービス (OpenSearch Service, Athena, SNS, EventBridge) を追加
- ミドルウェア項目に不足していたツール (ecspresso, lambroll, Locust) を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)